### PR TITLE
Support handling multiple paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,23 @@
 # hmacproxy HMAC authentication proxy server
 
-Originally forked from [18f/hmacauth](https://github.com/18F/hmacauth)
-
 This verifies requests have a valid hmac signature and if they do proxies them to the 
 appropriate server.
 
-This is intended for handling GitHub webhooks.
+This is intended for handling GitHub webhooks. The intention is to have a single loadbalancer
+that forwards all webhooks to the proxy which validates the request and then proxies them to the actual
+GitHub App. This approach gives us an extra layer of security which ensures we don't wholly rely on individual
+GitHub Apps authenticating the webhooks. Individual apps should still validate webhooks for added security.
 
-##
-README below this line is outdated.
+The proxy is configured with a YAML like the one below
 
-## 
-Proxy server that signs and authenticates HTTP requests using an HMAC
-signature; uses the [github.com/18F/hmacauth Go package](https://github.com/18F/hmacauth).
-
-[![Build Status](https://travis-ci.org/18F/hmacproxy.svg?branch=master)](https://travis-ci.org/18F/hmacproxy)
-
-[![Coverage Status](https://coveralls.io/repos/18F/hmacproxy/badge.svg?branch=master&service=github)](https://coveralls.io/github/18F/hmacproxy?branch=master)
-
-## Installation
-
-For now, install from source:
-
-```sh
-$ go get github.com/18F/hmacproxy
+```yaml
+routes:
+  - path: "/api/github/annotate/webhook"
+    upstream: "http://localhost:80/api/github/webhook"
 ```
 
-## Testing out locally
+A request must exactly match the path in order to be proxied to the target location.
 
-The following will authenticate local requests and return a status of 202 if
-everything works. Change the values for `-secret`, `-sign-header`, and
-`-headers` to simulate authentication failures.
+## References
 
-In the first shell:
-
-```sh
-$ hmacproxy -port 8081 -secret "foobar" -sign-header "X-Signature" -auth
-
-127.0.0.1:8081: responding Accepted/Unauthorized for auth queries
-```
-
-In the second shell:
-
-```sh
-$ hmacproxy -port 8080 -secret "foobar" -sign-header "X-Signature" \
-  -upstream http://localhost:8081/
-
-127.0.0.1:8080: proxying signed requests to: http://localhost:8081/
-```
-
-In the third shell:
-
-```sh
-$ curl -i localhost:8080/18F/hmacproxy
-
-HTTP/1.1 202 Accepted
-Content-Length: 0
-Content-Type: text/plain; charset=utf-8
-Date: Mon, 05 Oct 2015 15:32:56 GMT
-```
-
-##  Proxying to an upstream server
-
-```sh
-$ hmacproxy -port 8080 -secret "foobar" -sign-header "X-Signature" \
-  -upstream https://my-upstream.com/
-```
-
-## Accepting incoming requests over SSL
-
-If you wish to expose the proxy endpoints directly to the public, rather than
-via an Nginx proxy scheme, pass the `-ssl-cert` and `-ssl-key` options along
-all other `-auth` parameters.
-
-## Public domain
-
-This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
-
-> This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
->
-> All contributions to this project will be released under the CC0
->dedication. By submitting a pull request, you are agreeing to comply
->with this waiver of copyright interest.
+Originally forked from [18f/hmacauth](https://github.com/18F/hmacauth)

--- a/example.yaml
+++ b/example.yaml
@@ -1,0 +1,4 @@
+# Example of a mappings file
+routes:
+  - path: "/api/github/annotate/webhook"
+    upstream: "http://localhost:80/webhook/"

--- a/handlers.go
+++ b/handlers.go
@@ -2,35 +2,93 @@ package main
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/jlewi/hydros/pkg/util"
+	"github.com/pkg/errors"
 
 	"github.com/go-logr/zapr"
 	"github.com/jlewi/hmacproxy/pkg/hmacauth"
 	"go.uber.org/zap"
 )
 
+const (
+	healthPath = "/healthz"
+)
+
+// Mappings is a list of paths and the upstream to map them to
+type Mappings struct {
+	Routes []Route `yaml:"routes,omitempty"`
+}
+
+type Route struct {
+	// Path to math
+	Path     string `yaml:"path,omitempty"`
+	Upstream string `yaml:"upstream,omitempty"`
+}
+
 // NewHTTPProxyHandler returns a http.Handler and its description based on the
 // configuration specified in opts.
-func NewHTTPProxyHandler(opts *HmacProxyOpts) (handler http.Handler, description string) {
+func NewHTTPProxyHandler(opts *HmacProxyOpts) (*ProxyHandler, error) {
 	log := zapr.NewLogger(zap.L())
 	bodyOnly := true
 	log.Info("Creating hmacauth", "digest", opts.Digest.ID, "header", opts.SignHeader, "headers", opts.Headers, "bodyOnly", bodyOnly)
 	auth := hmacauth.NewHmacAuth(opts.Digest.ID,
 		[]byte(opts.Secret), opts.SignHeader, opts.Headers, true)
 
-	return authAndProxyHandler(auth, &opts.Upstream)
+	if len(opts.Mappings.Routes) == 0 {
+		return nil, errors.New("At least one route must be specified in mappings")
+	}
+
+	h := &ProxyHandler{
+		auth:     auth,
+		handlers: make(map[string]http.Handler),
+	}
+
+	invalidUpstream := make([]string, 0, len(opts.Mappings.Routes))
+	for _, r := range opts.Mappings.Routes {
+		if r.Path == healthPath {
+			return nil, errors.Errorf("Path %v is a reserved path and can't be proxied", r.Path)
+		}
+
+		log.Info("Create proxy route", "path", r.Path, "upstream", r.Upstream)
+
+		u, msg := parseUpstream(r.Upstream)
+
+		if msg != "" {
+			invalidUpstream = append(invalidUpstream, msg)
+			continue
+		}
+		proxy := newRewritePathProxy(u)
+		// Configure the proxy not to check https certificates.
+		log.Info("Proxy configured to skip TLS verification")
+		proxy.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+
+		h.handlers[r.Path] = proxy
+	}
+
+	if len(invalidUpstream) > 0 {
+		return nil, errors.New(strings.Join(invalidUpstream, "; "))
+	}
+	return h, nil
 }
 
-type authHandler struct {
-	auth    *hmacauth.HmacAuth
-	handler http.Handler
+type ProxyHandler struct {
+	auth *hmacauth.HmacAuth
+	// handler s from a path to the reverse proxy handler for that path
+	handlers map[string]http.Handler
 }
 
-func (h authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log := zapr.NewLogger(zap.L())
 	// Add a health check.
-	if r.URL.Path == "/healthz" {
+	if r.URL.Path == healthPath {
 		w.Write([]byte("ok"))
 		return
 	}
@@ -39,21 +97,62 @@ func (h authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if result != hmacauth.ResultMatch {
 		log.Info("unauthorized request", "url", r.URL, "signature", headerSignature, "computedSignature", computedSignature)
 		http.Error(w, "unauthorized request", http.StatusUnauthorized)
+		return
+	}
+
+	p, ok := h.handlers[r.URL.Path]
+
+	if !ok {
+		log.Info("Unhandled path", "path", r.URL.Path)
+		http.NotFound(w, r)
+		return
+	}
+	log.V(util.Debug).Info("Proxy request", "path", r.URL.Path)
+	p.ServeHTTP(w, r)
+}
+
+// parseUpstream checks the raw URL can be parsed and is valid
+func parseUpstream(raw string) (*url.URL, string) {
+	u, err := url.Parse(raw)
+
+	if err != nil {
+		return nil, fmt.Sprintf("Could not parse URL %v", raw)
+	}
+
+	problems := make([]string, 0, 5)
+	if u.Scheme == "" {
+		problems = append(problems, "scheme not specified")
+	} else if !(u.Scheme == "http" || u.Scheme == "https") {
+		problems = append(problems, "invalid upstream scheme: "+u.Scheme)
+	}
+	if u.Host == "" {
+		problems = append(problems, "host not specified")
+	}
+
+	if len(problems) == 0 {
+		return u, ""
 	} else {
-		h.handler.ServeHTTP(w, r)
+		return nil, fmt.Sprintf("upstream %v is not valid; %v", raw, strings.Join(problems, ", "))
 	}
 }
 
-func authAndProxyHandler(auth *hmacauth.HmacAuth, upstream *HmacProxyURL) (
-	handler http.Handler, description string) {
-	log := zapr.NewLogger(zap.L())
-	description = "proxying authenticated requests to: " + upstream.Raw
-	proxy := httputil.NewSingleHostReverseProxy(upstream.URL)
-	// Configure the proxy not to check https certificates.
-	log.Info("Proxy configured to skip TLS verification")
-	proxy.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+// newRewritePathPrxy returns a proxy that forwards to the specified target
+func newRewritePathProxy(target *url.URL) *httputil.ReverseProxy {
+	targetQuery := target.RawQuery
+	director := func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.URL.Path = target.Path
+		req.URL.RawPath = target.RawPath
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
 	}
-	handler = authHandler{auth, proxy}
-	return
+	return &httputil.ReverseProxy{Director: director}
 }

--- a/options.go
+++ b/options.go
@@ -18,7 +18,7 @@ type HmacProxyOpts struct {
 	Secret     string
 	SignHeader string
 	Headers    HmacProxyHeaders
-	Upstream   HmacProxyURL
+	Mappings   Mappings
 	SslCert    string
 	SslKey     string
 }
@@ -31,7 +31,6 @@ func (opts *HmacProxyOpts) Validate() (err error) {
 	var msgs []string
 	msgs = validatePort(opts, msgs)
 	msgs = validateAuthParams(opts, msgs)
-	msgs = validateUpstream(opts, msgs)
 	msgs = validateSsl(opts, msgs)
 
 	if len(msgs) != 0 {
@@ -115,30 +114,6 @@ func validateAuthParams(opts *HmacProxyOpts, msgs []string) []string {
 type HmacProxyURL struct {
 	Raw string
 	URL *url.URL
-}
-
-func validateUpstream(opts *HmacProxyOpts, msgs []string) []string {
-	if opts.Upstream.Raw == "" {
-		return msgs
-	}
-
-	var err error
-	if opts.Upstream.URL, err = url.Parse(opts.Upstream.Raw); err != nil {
-		msgs = append(msgs, "upstream URL failed to parse"+err.Error())
-	}
-	scheme := opts.Upstream.URL.Scheme
-	if scheme == "" {
-		msgs = append(msgs, "upstream scheme not specified")
-	} else if !(scheme == "http" || scheme == "https") {
-		msgs = append(msgs, "invalid upstream scheme: "+scheme)
-	}
-	if host := opts.Upstream.URL.Host; host == "" {
-		msgs = append(msgs, "upstream host not specified")
-	}
-	if path := opts.Upstream.URL.RequestURI(); path != "/" {
-		msgs = append(msgs, "upstream path must be \"/\", not "+path)
-	}
-	return msgs
 }
 
 func checkExistenceAndPermission(path, optionName, dirOrFile string,

--- a/pkg/hmacauth/hmacauth.go
+++ b/pkg/hmacauth/hmacauth.go
@@ -1,5 +1,11 @@
 package hmacauth
 
+// TODO(jeremy): This is a more general implementation of hmac then what GitHub requires; in particular
+// it supports including headers in the signature. It was inherited from the code I originally forked to create
+// the proxy server. We could potentially simplify the code and use
+// https://github.com/google/go-github/blob/18cd63d0e2bda56f9018d7f85bf11f81e6ce2dd2/github/messages.go to
+// validate the payload. That function is also used by palantir's github apps.
+
 import (
 	"bytes"
 	"crypto"


### PR DESCRIPTION
* Use a YAML file to configure the mappings

* Only match the listed paths exactly and support forwarding them to a different path.

* This enables having a single point of ingress for multiple GitHub webhooks that ensures requests are properly authenticated before proxying to the application.